### PR TITLE
Add document manager and filter manager interface alias for autowire

### DIFF
--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -1,4 +1,8 @@
 services:
+    # Autowire alias
+    BestIt\CommercetoolsODM\Filter\FilterManagerInterface: '@best_it.commercetools_odm.filter.filter_manager'
+    BestIt\CommercetoolsODM\DocumentManagerInterface: '@best_it.commercetools_odm.manager'
+
     best_it.commercetools_odm.action_builder.factory.default:
         class: BestIt\CommercetoolsODM\ActionBuilder\ActionBuilderFactory
         arguments: ['@cache.system']


### PR DESCRIPTION
Just add alias for the interfaces for supporting autowire without BC.